### PR TITLE
[ModemConfig] Fix null/empty string issues, show multiple grouped notifications for DSDS configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 **/.idea
 **/*.iml
 **/*.ipr
+**/lib
+**/gen

--- a/ModemConfig/AndroidManifest.xml
+++ b/ModemConfig/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <application
         android:directBootAware="true"
+        android:icon="@drawable/ic_sim_card"
         android:label="@string/app_name"
         android:persistent="true">
         <receiver

--- a/ModemConfig/res/values-de/strings.xml
+++ b/ModemConfig/res/values-de/strings.xml
@@ -3,6 +3,7 @@
     <string name="notification_channel_configuration_info">Konfigurationsinfo</string>
 
     <string name="notification_title_modem_configuration">Modem-Konfiguration</string>
-    <string name="notification_text_modem_configuration_resolved_modem_config">Benutze Modem-Konfiguration: %1$s\nFirmware-Datei: %2$s</string>
+    <string name="notification_title_slot_index">Steckplatz %1$s</string>
+    <string name="notification_text_modem_configuration_resolved_modem_config">Modem-Konfiguration: %1$s\nFirmware-Datei: %2$s</string>
     <string name="notification_text_modem_configuration_no_match">Keine passende Modem-Konfiguration gefunden</string>
 </resources>

--- a/ModemConfig/res/values-fr/strings.xml
+++ b/ModemConfig/res/values-fr/strings.xml
@@ -3,6 +3,7 @@
     <string name="notification_channel_configuration_info">Informations de configuration</string>
 
     <string name="notification_title_modem_configuration">Configuration du modem</string>
-    <string name="notification_text_modem_configuration_resolved_modem_config">Configuration du modem utilisée : %1$s\nFirmware utilisé: %2$s</string>
-    <string name="notification_text_modem_configuration_no_match">Aucune configuration de modem trouvée </string>
+    <string name="notification_title_slot_index">Port SIM %1$s</string>
+    <string name="notification_text_modem_configuration_resolved_modem_config">Configuration du modem utilisée : %1$s\n Chemin d\'accès du firmware : %2$s</string>
+    <string name="notification_text_modem_configuration_no_match">Aucune configuration modem Trouvée</string>
 </resources>

--- a/ModemConfig/res/values-it/strings.xml
+++ b/ModemConfig/res/values-it/strings.xml
@@ -3,6 +3,7 @@
     <string name="notification_channel_configuration_info">Informazioni configurazione</string>
 
     <string name="notification_title_modem_configuration">Configurazione Modem</string>
-    <string name="notification_text_modem_configuration_resolved_modem_config">Uso configurazione modem %1$s\nFile firmware: %2$s</string>
+    <string name="notification_title_slot_index">Slot %1$s</string>
+    <string name="notification_text_modem_configuration_resolved_modem_config">Configurazione modem: %1$s\nFile firmware: %2$s</string>
     <string name="notification_text_modem_configuration_no_match">Nessuna configurazione modem trovata</string>
 </resources>

--- a/ModemConfig/res/values-it/strings.xml
+++ b/ModemConfig/res/values-it/strings.xml
@@ -3,6 +3,6 @@
     <string name="notification_channel_configuration_info">Informazioni configurazione</string>
 
     <string name="notification_title_modem_configuration">Configurazione Modem</string>
-    <string name="notification_text_modem_configuration_resolved_modem_config">Uso configurazione modem %1$s\nFile firmware: %2%$s</string>
+    <string name="notification_text_modem_configuration_resolved_modem_config">Uso configurazione modem %1$s\nFile firmware: %2$s</string>
     <string name="notification_text_modem_configuration_no_match">Nessuna configurazione modem trovata</string>
 </resources>

--- a/ModemConfig/res/values/strings.xml
+++ b/ModemConfig/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">ModemConfig</string>
+    <string name="app_name" translatable="false">Open Devices ModemConfig</string>
 
     <string name="modem_config_path" translatable="false">/oem/modem-config</string>
     <string name="modem_config_name" translatable="false">modem.conf</string>
@@ -8,6 +8,7 @@
     <string name="notification_channel_configuration_info">Configuration info</string>
 
     <string name="notification_title_modem_configuration">Modem configuration</string>
-    <string name="notification_text_modem_configuration_resolved_modem_config">Using modem configuration: %1$s\nFirmware file: %2$s</string>
-    <string name="notification_text_modem_configuration_no_match">Found no modem configuration</string>
+    <string name="notification_title_slot_index">Slot %1$s</string>
+    <string name="notification_text_modem_configuration_resolved_modem_config">Modem configuration: %1$s\nFirmware file: %2$s</string>
+    <string name="notification_text_modem_configuration_no_match">No modem configuration found</string>
 </resources>

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -237,7 +237,7 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
         val channel = NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
                 resources.getString(R.string.notification_channel_configuration_info),
-                NotificationManager.IMPORTANCE_LOW)
+                NotificationManager.IMPORTANCE_MIN)
         notificationManager.createNotificationChannel(channel)
 
         // Our callback is invoked once on .add too; no need to run the contents manually at startup

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -36,7 +36,9 @@ import java.nio.file.Paths
 private const val TAG = "ModemConfigReceiver"
 private const val VERBOSE = false
 private const val NOTIFICATION_CHANNEL_ID = "Configuration"
+private const val NOTIFICATION_GROUP_KEY_SLOTS = "com.sony.opentelephony.modemconfig.slot_result"
 private const val NOTIFICATION_ID = 1
+private const val NOTIFICATION_ID_SLOT_BASE = 1000
 
 private val newlineMatch = Regex("[\n\r]")
 
@@ -209,15 +211,22 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
             resources.getString(R.string.notification_text_modem_configuration_no_match)
         }
 
-        val notification = Notification.Builder(this, NOTIFICATION_CHANNEL_ID).run {
-            setSmallIcon(R.drawable.ic_sim_card)
-            setContentTitle(resources.getString(R.string.notification_title_modem_configuration))
-            setContentText(notificationText.substringBefore('\n'))
-            style = Notification.BigTextStyle().bigText(notificationText)
-            build()
-        }
+        val notification = Notification.Builder(this@ModemConfigService,
+                                                NOTIFICATION_CHANNEL_ID)
+                .run {
+                    setSmallIcon(R.drawable.ic_sim_card)
+                    setContentTitle(resources.getString(
+                            R.string.notification_title_slot_index,
+                            sub.simSlotIndex))
+                    setContentText(notificationText.substringBefore('\n'))
+                    setGroup(NOTIFICATION_GROUP_KEY_SLOTS)
+                    setSortKey(sub.simSlotIndex.toString())
+                    style = Notification.BigTextStyle()
+                            .bigText(notificationText)
+                    build()
+                }
 
-        notificationManager.notify(NOTIFICATION_ID, notification)
+        notificationManager.notify(NOTIFICATION_ID_SLOT_BASE + sub.simSlotIndex, notification)
     }
 
     override fun onCreate() {
@@ -238,7 +247,27 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
                     // caching at all. The modem-switcher itself makes sure to not needlessly flash
                     // firmware - let it handle the validation.
                     override fun onSubscriptionsChanged() {
-                        sm.activeSubscriptionInfoList?.forEach(::handleSubscription)
+                        sm.activeSubscriptionInfoList?.run {
+                            if (any()) {
+                                val summaryNotification = Notification.Builder(
+                                        this@ModemConfigService,
+                                        NOTIFICATION_CHANNEL_ID)
+                                        .run {
+                                            setSmallIcon(R.drawable.ic_sim_card)
+                                            setContentTitle(resources.getString(
+                                                    R.string.notification_title_modem_configuration
+                                            ))
+                                            setGroup(NOTIFICATION_GROUP_KEY_SLOTS)
+                                            setGroupSummary(true)
+                                            build()
+                                        }
+
+                                notificationManager.notify(NOTIFICATION_ID, summaryNotification)
+                            }
+
+                            forEach(::handleSubscription)
+                        }
+
                     }
                 })
     }


### PR DESCRIPTION
Deal with values that are null/empty indicating the SIM has not been unlocked yet or is otherwise not ready -> do nothing in this case (instead of crashing).

Configuring a second sim would previously overwrite the notification of the first. Not anymore :)
