### PR TITLE
[OpenTelephony] ModemConfig: Fall back to generic-IMS if no match is found

### DIFF
--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -168,8 +168,8 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
         }
 
         return if (result == null) {
-            Log.w(TAG, "No matching config found")
-            null
+            Log.w(TAG, "No matching config found, falling back to generic IMS")
+            "S9999.9"
         } else {
             Log.i(TAG, "Matched with $result")
             result.sim_config_id


### PR DESCRIPTION
Generic IMS allows carriers with an unknown configuration (in the
current mapping) to still use IMS if they end up supporting it.

If sony-modem-switcher ends up not finding the config or the modem file
it'll (as always) fall back to the default non_ims variant anyway.

---

@kholk anything else to add?
