### PR TITLE
[R] Convert ModemConfig to sysprop and drop private platform apis

### DIFF
--- a/ModemConfig/Android.bp
+++ b/ModemConfig/Android.bp
@@ -9,7 +9,7 @@ android_app {
 
     required: ["privapp_whitelist_com.sony.opentelephony.modemconfig"],
 
-    platform_apis: true,
+    sdk_version: "system_current",
 }
 
 prebuilt_etc {

--- a/ModemConfig/Android.bp
+++ b/ModemConfig/Android.bp
@@ -9,6 +9,8 @@ android_app {
 
     required: ["privapp_whitelist_com.sony.opentelephony.modemconfig"],
 
+    libs: ["SomcModemProperties"],
+
     sdk_version: "system_current",
 }
 

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -28,6 +28,7 @@ import android.telephony.SubscriptionManager
 import android.telephony.TelephonyManager
 import android.text.TextUtils
 import android.util.Log
+import com.sony.opentelephony.modemconfig.SomcModemProperties
 import org.xmlpull.v1.XmlPullParser
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -198,6 +199,14 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
         val name = findConfigurationName(this, tm)
 
         val notificationText = if (name != null) {
+            val prop = "persist.somc.cust.modem${sub.simSlotIndex}"
+            Log.d(TAG, "Setting $prop to $name")
+            when (sub.simSlotIndex) {
+                0 -> SomcModemProperties.cust_modem_0(name)
+                1 -> SomcModemProperties.cust_modem_1(name)
+                else -> throw Exception("Unknown slotIdx ${sub.simSlotIndex}")
+            }
+
             resources.getString(
                     R.string.notification_text_modem_configuration_resolved_modem_config,
                     name,

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -168,8 +168,8 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
         }
 
         return if (result == null) {
-            Log.w(TAG, "No matching config found")
-            null
+            Log.w(TAG, "No matching config found, falling back to generic IMS")
+            "S9999.9"
         } else {
             Log.i(TAG, "Matched with $result")
             result.sim_config_id

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -23,7 +23,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import android.os.SystemProperties
 import android.telephony.SubscriptionInfo
 import android.telephony.SubscriptionManager
 import android.telephony.TelephonyManager
@@ -199,10 +198,6 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
         val name = findConfigurationName(this, tm)
 
         val notificationText = if (name != null) {
-            val prop = "persist.vendor.somc.cust.modem${sub.simSlotIndex}"
-            if (VERBOSE) Log.v(TAG, "Setting $prop to $name")
-            SystemProperties.set(prop, name)
-
             resources.getString(
                     R.string.notification_text_modem_configuration_resolved_modem_config,
                     name,

--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -73,16 +73,7 @@ class ModemConfigService : Service() {
         val currentMap = hashMapOf<String, String>()
         var simConfigId: String? = null
 
-        // TODO: Kotlin .use {} block doesn't work here, while it does in regular apps...
-        /*
-modemconfig/ModemConfigReceiver.kt:63:70: error: unresolved reference. None of the following
-    candidates is applicable because of receiver type mismatch:
-@InlineOnly public inline fun <T : Closeable?, R> ???.use(block: (???) -> ???): ???
-    defined in kotlin.io
-context.resources.getXml(R.xml.service_provider_sim_configs).use {
-         */
-        val xml = context.resources.getXml(R.xml.service_provider_sim_configs)
-        try {
+        context.resources.getXml(R.xml.service_provider_sim_configs).use { xml ->
             while (xml.next() != XmlPullParser.END_DOCUMENT) {
                 if (xml.eventType == XmlPullParser.END_TAG &&
                     xml.name == "service_provider_sim_config") {
@@ -117,9 +108,6 @@ context.resources.getXml(R.xml.service_provider_sim_configs).use {
                     currentMap[xml.name] = text
                 }
             }
-
-        } finally {
-            xml.close()
         }
 
         list.sortByDescending { it.specificity() }

--- a/ModemConfig/sysprop/Android.bp
+++ b/ModemConfig/sysprop/Android.bp
@@ -1,0 +1,9 @@
+sysprop_library {
+    name: "SomcModemProperties",
+    proprietary: true,
+
+    srcs: ["SomcModemProperties.sysprop"],
+
+    property_owner: "Vendor",
+    api_packages: ["android.sysprop"],
+}

--- a/ModemConfig/sysprop/README.md
+++ b/ModemConfig/sysprop/README.md
@@ -1,0 +1,14 @@
+### Updating sysprop files
+
+#### Android 11 (R)
+
+Optional when not lunched for a device:
+```sh
+lunch sdk # (Can use sdk-eng too)
+export ALLOW_MISSING_DEPENDENCIES=true # Ignore errors about hostapd, wpa_supplicant etc missing
+```
+
+```sh
+build/soong/scripts/gen-sysprop-api-files.sh "vendor/oss/opentelephony/ModemConfig/sysprop" "SomcModemProperties"
+m SomcModemProperties-dump-api && rm -rf vendor/oss/opentelephony/ModemConfig/sysprop/api/SomcModemProperties-current.txt && cp -f out/soong/.intermediates/vendor/oss/opentelephony/ModemConfig/sysprop/SomcModemProperties_sysprop_library/api-dump.txt vendor/oss/opentelephony/ModemConfig/sysprop/api/SomcModemProperties-current.txt
+```

--- a/ModemConfig/sysprop/SomcModemProperties.sysprop
+++ b/ModemConfig/sysprop/SomcModemProperties.sysprop
@@ -1,0 +1,18 @@
+module: "com.sony.opentelephony.modemconfig.SomcModemProperties"
+owner: Vendor
+
+prop {
+    api_name: "cust_modem_0"
+    type: String
+    scope: Internal
+    access: ReadWrite
+    prop_name: "vendor.somc.cust.modem0"
+}
+
+prop {
+    api_name: "cust_modem_1"
+    type: String
+    scope: Internal
+    access: ReadWrite
+    prop_name: "vendor.somc.cust.modem1"
+}

--- a/ModemConfig/sysprop/api/SomcModemProperties-current.txt
+++ b/ModemConfig/sysprop/api/SomcModemProperties-current.txt
@@ -1,0 +1,18 @@
+props {
+  owner: Vendor
+  module: "com.sony.opentelephony.modemconfig.SomcModemProperties"
+  prop {
+    api_name: "cust_modem_0"
+    type: String
+    access: ReadWrite
+    scope: Internal
+    prop_name: "vendor.somc.cust.modem0"
+  }
+  prop {
+    api_name: "cust_modem_1"
+    type: String
+    access: ReadWrite
+    scope: Internal
+    prop_name: "vendor.somc.cust.modem1"
+  }
+}


### PR DESCRIPTION
Depends on #2

@jerpelea This needs a new branch; I'll update the base branch as soon as you made `r-mr1` and/or branched `q-mr1` :wink: 

---

On Android R we can finally use the sysprop API the way it's intended without all kinds of obnoxious, obscure errors in Java-land :tada: 

Without `SystemProperties` we can finally drop `platform_apis` and be properly API compliant too :confetti_ball: :grimacing: 