### PR TITLE
[ModemConfig] [R] Fixup sysprop refactor

### DIFF
--- a/ModemConfig/Android.bp
+++ b/ModemConfig/Android.bp
@@ -9,7 +9,7 @@ android_app {
 
     required: ["privapp_whitelist_com.sony.opentelephony.modemconfig"],
 
-    libs: ["SomcModemProperties"],
+    static_libs: ["SomcModemProperties"],
 
     sdk_version: "system_current",
 }

--- a/ModemConfig/sysprop/SomcModemProperties.sysprop
+++ b/ModemConfig/sysprop/SomcModemProperties.sysprop
@@ -6,7 +6,7 @@ prop {
     type: String
     scope: Internal
     access: ReadWrite
-    prop_name: "vendor.somc.cust.modem0"
+    prop_name: "persist.vendor.somc.cust.modem0"
 }
 
 prop {
@@ -14,5 +14,5 @@ prop {
     type: String
     scope: Internal
     access: ReadWrite
-    prop_name: "vendor.somc.cust.modem1"
+    prop_name: "persist.vendor.somc.cust.modem1"
 }

--- a/ModemConfig/sysprop/api/SomcModemProperties-current.txt
+++ b/ModemConfig/sysprop/api/SomcModemProperties-current.txt
@@ -6,13 +6,13 @@ props {
     type: String
     access: ReadWrite
     scope: Internal
-    prop_name: "vendor.somc.cust.modem0"
+    prop_name: "persist.vendor.somc.cust.modem0"
   }
   prop {
     api_name: "cust_modem_1"
     type: String
     access: ReadWrite
     scope: Internal
-    prop_name: "vendor.somc.cust.modem1"
+    prop_name: "persist.vendor.somc.cust.modem1"
   }
 }


### PR DESCRIPTION
R changes were made long ago and only build-tested, these two fixups are necessary to make ModemConfig actually work on R; add back the `persist.` prefix that went missing (but is still in the log line) and use static linkage against the sysprop library.

Thanks @luk1337 for bringing these issues to my attention!