### PR TITLE
 ModemConfig: Convert providers list into readonly, lazy-initialized val

### DIFF
--- a/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
+++ b/ModemConfig/src/com/sony/opentelephony/modemconfig/ModemConfigService.kt
@@ -55,7 +55,11 @@ class ModemConfigService : Service() {
         fun specificity() = listOfNotNull(mcc, mnc, gid1, imsi, sp).count()
     }
 
-    private lateinit var providers: List<ProviderFilter>
+    private val providers: List<ProviderFilter> by lazy {
+        // WARNING: This lazy assumes `providers` is used after the service has started,
+        // parseProviders requires a valid Context to call `getResources()` on.
+        parseProviders()
+    }
 
     private val notificationManager: NotificationManager by lazy {
         getSystemService(NotificationManager::class.java)
@@ -217,9 +221,6 @@ class ModemConfigService : Service() {
 
     override fun onCreate() {
         Log.e(TAG, "Starting")
-
-        providers = parseProviders()
-
         val sm = getSystemService(SubscriptionManager::class.java)
                  ?: throw Exception("Expected SubscriptionManager, got null")
 


### PR DESCRIPTION
Supersedes #5 

This PR, split into two commits first resolves the `TODO` by converting `providers` to a `lazyinit`. In hindsight the compiler does not enforce any checks on this, basically turning it into a free nullable variable that does not need to be null-checked when used.

The second commit addresses this by using `lazy` instead. This is a nice way of providing a value for an immutable (`val`) at a later time (after the constructor), assuming it is used after `this` has a valid `Context`.