### PR TITLE
[S] ModemConfig: Set explicit value for android:exported

### DIFF
--- a/ModemConfig/AndroidManifest.xml
+++ b/ModemConfig/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:persistent="true">
         <receiver
             android:name=".BootReceiver"
-            android:enabled="true">
+            android:enabled="true"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />


### PR DESCRIPTION
Since the broadcast receiver doesn't need to receive messages from non-system sources outside its application this can be set to false: https://developer.android.com/guide/topics/manifest/receiver-element.html?hl=en#exported

Fixes:
    W PackageManager: Failed to parse /vendor/priv-app/ModemConfig: /vendor/priv-app/ModemConfig/ModemConfig.apk (at Binary XML file line #7): com.sony.opentelephony.modemconfig.BootReceiver: Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present