### PR TITLE
[T] ModemConfig: Add android.permission.POST_NOTIFICATIONS

### DIFF
--- a/ModemConfig/AndroidManifest.xml
+++ b/ModemConfig/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <service android:name=".ModemConfigService" />
     </application>
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />


### PR DESCRIPTION
Starting with Android 13 user has to give permission to receive notifications.
This permission seems to be pre-grant for privileged apps which is fine.
Without this permission there's no more notification.